### PR TITLE
fix: horizontal scroll on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -785,6 +785,7 @@ h2.action-head {
 		padding-left: 0;
 		padding-right: 0;
 		margin-left: 0;
+		margin-right: auto;
 	}
 	.newsletter-action-column {
 		max-width: unset;


### PR DESCRIPTION
# Description
Fixes a bug where there was horizontal space that was unused on the take action page on mobile

# Type of change
- [x] Correction (typos, outdated links, etc.)

# Misc Notes
<!--Include other notes you think are helpful here!-->
