### PR TITLE
Creates gitattributes to standardize line endings moving forward

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare files that will always have LF line endings on checkout.
+* text eol=lf


### PR DESCRIPTION
# Description
Sets line endings for all files to be standard, very helpful when people are working on both mac / windows as this removes files being massively changed between the two operating systems 

# Type of change
<!-- Delete options that are not relevant. -->
- [ ] Documentation update

# Misc Notes
<!--Include other notes you think are helpful here!-->
I don't have a strong opinion between crlf/lf. CRLF is the default for windows, LF is the default for mac.