### PR TITLE
feat: add legal disclaimer to newsletter signup

### DIFF
--- a/action.html
+++ b/action.html
@@ -305,7 +305,7 @@
 								<button class='button'>Sign up</button>
 							</div>
 						</div>
-						<em class="smaller">By signing up, you agree to Gaggle's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
+						<em class="smaller">By signing up, you agree to Gaggle Mail's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
 					</form>`;
 						let form = document.getElementById("newsletter-form")
 						let error = document.getElementById("error-label")

--- a/action.html
+++ b/action.html
@@ -268,9 +268,9 @@
 						</noscript>
 					</div>
 				</div>
-				
+
 				<div class="wrapper-full">
-					
+
 					<h2 id="socials"><span class="red">Follow</span> us on:
 					<div class="header-copy"><noscript><a href="#posts"></a></noscript></div>
 					</h2>
@@ -305,6 +305,7 @@
 								<button class='button'>Sign up</button>
 							</div>
 						</div>
+						<em class="smaller">By signing up, you agree to Gaggle's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
 					</form>`;
 						let form = document.getElementById("newsletter-form")
 						let error = document.getElementById("error-label")

--- a/index.html
+++ b/index.html
@@ -187,6 +187,7 @@
 										<button class='button'>Sign up</button>
 									</div>
 								</div>
+								<em class="smaller">By signing up, you agree to Gaggle's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
 							</form>`;
 								let form = document.getElementById("newsletter-form")
 								let error = document.getElementById("error-label")

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
 										<button class='button'>Sign up</button>
 									</div>
 								</div>
-								<em class="smaller">By signing up, you agree to Gaggle's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
+								<em class="smaller">By signing up, you agree to Gaggle Mail's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
 							</form>`;
 								let form = document.getElementById("newsletter-form")
 								let error = document.getElementById("error-label")

--- a/newsletter.html
+++ b/newsletter.html
@@ -82,7 +82,7 @@
 							<button class='button'>Sign up</button>
 						</div>
 					</div>
-					<em class="smaller">By signing up, you agree to Gaggle's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
+					<em class="smaller">By signing up, you agree to Gaggle Mail's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
 				</form>`;
 					let form = document.getElementById("newsletter-form")
 					let error = document.getElementById("error-label")

--- a/newsletter.html
+++ b/newsletter.html
@@ -82,6 +82,7 @@
 							<button class='button'>Sign up</button>
 						</div>
 					</div>
+					<em class="smaller">By signing up, you agree to Gaggle's Terms of Service and Privacy Policy. <a href="https://gaggle.email/terms" target="_blank">Learn More</a></em>
 				</form>`;
 					let form = document.getElementById("newsletter-form")
 					let error = document.getElementById("error-label")


### PR DESCRIPTION
# Description
Adds legal disclaimer below the newsletter signup
![image](https://github.com/TBfighters/tbfightersdotorg/assets/76080854/91b77c69-573a-4844-80d9-b78cdf10a81d)
> It now says Gaggle Mail's instead of Gaggle's


# Type of change
<!-- Delete options that are not relevant. -->
- [x] Updated content (New CTA, updated wording, etc.)

# Misc Notes

