### PR TITLE
Remove default og-image tag from audit page

### DIFF
--- a/audit.html
+++ b/audit.html
@@ -11,7 +11,6 @@
 	<!--Open Graph Tags-->
 	<meta property="og:site_name" content="TBFighters" />
 	<meta property="og:url" content="https://tbfighters.org" />
-	<meta property="og:image" content="img/og-image.jpg" />
 	<meta property="og:type" content="website" />
 	<meta property="theme-color" content="#D7211E" />
 	<!-- Style Tags -->


### PR DESCRIPTION
# Type of change
<!-- Delete options that are not relevant. -->
- [ ] Correction (typos, outdated links, etc.)
