### PR TITLE
Fix typos: witholding, commerical, It's

### DIFF
--- a/action.html
+++ b/action.html
@@ -170,7 +170,7 @@
 						<strong>Featured action:</strong>
 					</p>
 					<p>
-						US: The State Department is currently <a href="https://www.npr.org/2026/04/04/nx-s1-5763938/hiv-aids-pepfar-funding-delays-may-shut-down-lifesaving-aid" target="_blank">witholding money from PEPFAR</a>, <a href="https://wapo.st/41Ld5T8" target="_blank">sunsetting global health programs</a>, and <a href="https://www.nytimes.com/2026/04/06/health/trump-foreign-aid.html?smid=nytcore-ios-share" target="_blank">tying some of the rest to commerical interests</a>. <a href="https://win.newmode.net/pih/congressionaloversightoverthemouprocess" target="_blank">Contact your representatives</a> to ensure funding keeps flowing!
+						US: The State Department is currently <a href="https://www.npr.org/2026/04/04/nx-s1-5763938/hiv-aids-pepfar-funding-delays-may-shut-down-lifesaving-aid" target="_blank">withholding money from PEPFAR</a>, <a href="https://wapo.st/41Ld5T8" target="_blank">sunsetting global health programs</a>, and <a href="https://www.nytimes.com/2026/04/06/health/trump-foreign-aid.html?smid=nytcore-ios-share" target="_blank">tying some of the rest to commercial interests</a>. <a href="https://win.newmode.net/pih/congressionaloversightoverthemouprocess" target="_blank">Contact your representatives</a> to ensure funding keeps flowing!
 					</p>
 					<div class="buttons">
 						<a href="https://win.newmode.net/pih/congressionaloversightoverthemouprocess" class="button" target="_blank">Email your
@@ -383,7 +383,7 @@
 											alt="phone icon" class="icon" />
 										<strong>Act Now: <span
 												class="red">Demand</span></strong>
-										Australia Increase It's AID Budget
+										Australia Increase Its AID Budget
 									</p>
 									<a href="https://www.results.org.au/write-to-your-mp"
 										class="button"

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
 							<strong>Featured action:</strong>
 						</p>
 						<p>
-							US: The State Department is currently <a href="https://www.npr.org/2026/04/04/nx-s1-5763938/hiv-aids-pepfar-funding-delays-may-shut-down-lifesaving-aid" target="_blank">witholding money from PEPFAR</a>, <a href="https://wapo.st/41Ld5T8" target="_blank">sunsetting global health programs</a>, and <a href="https://www.nytimes.com/2026/04/06/health/trump-foreign-aid.html?smid=nytcore-ios-share" target="_blank">tying some of the rest to commerical interests</a>. <a href="https://win.newmode.net/pih/congressionaloversightoverthemouprocess" target="_blank">Contact your representatives</a> to ensure funding keeps flowing!
+							US: The State Department is currently <a href="https://www.npr.org/2026/04/04/nx-s1-5763938/hiv-aids-pepfar-funding-delays-may-shut-down-lifesaving-aid" target="_blank">withholding money from PEPFAR</a>, <a href="https://wapo.st/41Ld5T8" target="_blank">sunsetting global health programs</a>, and <a href="https://www.nytimes.com/2026/04/06/health/trump-foreign-aid.html?smid=nytcore-ios-share" target="_blank">tying some of the rest to commercial interests</a>. <a href="https://win.newmode.net/pih/congressionaloversightoverthemouprocess" target="_blank">Contact your representatives</a> to ensure funding keeps flowing!
 						</p>
 						<div class="buttons">
 							<a href="https://win.newmode.net/pih/congressionaloversightoverthemouprocess" class="button" target="_blank">Email your


### PR DESCRIPTION
## Summary
- Fix "witholding" → "withholding" in featured action text (index.html, action.html)
- Fix "commerical" → "commercial" in featured action text (index.html, action.html)
- Fix "It's AID Budget" → "Its AID Budget" on the Australia action card (action.html)

## Test plan
- [ ] Visual check of featured action paragraph on home and action pages
- [ ] Visual check of Australia action card on action page